### PR TITLE
Convert to xstream and support diversity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Cycle Mouse Position](http://raquelxmoss.github.io/cycle-mouse-position)
+# [Cycle Mouse Position](http://cyclejs-community.github.io/cycle-mouse-position)
 
 Have you ever wanted a stream of mouse positions for your Cycle application? Then this driver is for you!
 
@@ -7,6 +7,7 @@ Have you ever wanted a stream of mouse positions for your Cycle application? The
 ```bash
 $ npm install cycle-mouse-position --save
 ```
+Cycle Mouse Position is stream library agnostic. You should be able to use it with RxJs, xstream, or whatever you like. Please [open an issue](https://github.com/cyclejs-community/cycle-mouse-position/issues) if you have any troubles, and note which stream library you are using.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ const mousePosition$ = MousePosition.positions();
 
 ## Example
 
-**[Try this example online](http://raquelxmoss.github.io/cycle-mouse-position)** 
+**[Try this example online](http://raquelxmoss.github.io/cycle-mouse-position)**
 
 ```javascript
-import {run} from '@cycle/core';
+import {run} from '@cycle/xstream-run';
 import {makeDOMDriver, div, h1, h3} from '@cycle/dom';
 import {makeMousePositionDriver} from 'cycle-mouse-position'
-import {Observable} from 'rx';
+import xs from 'xstream';
 
 export default function main({DOM, MousePosition}){
   const mousePosition$ = MousePosition.positions();

--- a/examples/readme/app.js
+++ b/examples/readme/app.js
@@ -1,4 +1,4 @@
-import {Observable} from 'rx';
+import xs from 'xstream';
 import {div, h1, h3} from '@cycle/dom';
 
 export default function main({DOM, MousePosition}){

--- a/examples/readme/app.js
+++ b/examples/readme/app.js
@@ -1,7 +1,6 @@
-import xs from 'xstream';
 import {div, h1, h3} from '@cycle/dom';
 
-export default function main({DOM, MousePosition}){
+export default function main ({DOM, MousePosition}) {
   const mousePosition$ = MousePosition.positions();
 
   return {
@@ -13,5 +12,5 @@ export default function main({DOM, MousePosition}){
         ]
       )
     )
-  }
+  };
 }

--- a/examples/readme/index.js
+++ b/examples/readme/index.js
@@ -1,7 +1,6 @@
-import {run} from '@cycle/core';
+import {run} from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
-import {makeMousePositionDriver} from '../../src/mouse-position-driver'
-import {Observable} from 'rx';
+import {makeMousePositionDriver} from '../../src/mouse-position-driver';
 
 var app = require('./app').default;
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
   },
   "homepage": "https://github.com/raquelxmoss/cycle-mouse-position#readme",
   "dependencies": {
+    "@cycle/xstream-adapter": "^3.0.2",
     "xstream": "^5.3.2"
   },
   "devDependencies": {
     "@cycle/dom": "^11.0.1",
+    "@cycle/rx-adapter": "^3.0.0",
     "@cycle/xstream-run": "^3.0.3",
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   },
   "homepage": "https://github.com/raquelxmoss/cycle-mouse-position#readme",
   "dependencies": {
-    "rx": "^4.1.0"
+    "xstream": "^5.3.2"
   },
   "devDependencies": {
-    "@cycle/core": "^6.0.3",
-    "@cycle/dom": "^9.4.0",
+    "@cycle/dom": "^11.0.1",
+    "@cycle/xstream-run": "^3.0.3",
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",

--- a/src/mouse-position-driver.js
+++ b/src/mouse-position-driver.js
@@ -1,15 +1,15 @@
-import {Observable} from 'rx';
+import fromEvent from 'xstream/extra/fromEvent';
 
 export function makeMousePositionDriver () {
   return function mousePositionDriver () {
     return {
       positions () {
-        return Observable.fromEvent(document, 'mousemove')
+        return fromEvent(document, 'mousemove')
           .map(ev => {
             return {x: ev.clientX, y: ev.clientY}
           }
         )
-        .startWith({x: null, y: null})
+        .startWith({x: 0, y: 0})
       }
     }
   }

--- a/src/mouse-position-driver.js
+++ b/src/mouse-position-driver.js
@@ -1,16 +1,19 @@
 import fromEvent from 'xstream/extra/fromEvent';
+import xstreamAdapter from '@cycle/xstream-adapter';
 
 export function makeMousePositionDriver () {
-  return function mousePositionDriver () {
+  return function mousePositionDriver (sinks, streamAdapter) {
     return {
       positions () {
-        return fromEvent(document, 'mousemove')
+        const positions$ = fromEvent(document, 'mousemove')
           .map(ev => {
-            return {x: ev.clientX, y: ev.clientY}
+            return {x: ev.clientX, y: ev.clientY};
           }
         )
-        .startWith({x: 0, y: 0})
+        .startWith({x: 0, y: 0});
+
+        return streamAdapter.adapt(positions$, xstreamAdapter.streamSubscribe);
       }
-    }
-  }
+    };
+  };
 }

--- a/test/mouse-position-test.js
+++ b/test/mouse-position-test.js
@@ -8,11 +8,15 @@ describe("makeMousePositionDriver", () => {
     it("returns a stream of mouse positions", (done) => {
       const sources = makeMousePositionDriver()();
 
-      sources.positions().take(1).subscribe(() => done());
+      sources.positions().take(1).addListener({
+        next: () => {
+          const event = simulant('mousemove');
 
-      const event = simulant('mousemove');
-
-      simulant.fire(document.body, event);
+          simulant.fire(document.body, event);
+        },
+        error: done,
+        complete: done
+      });
     });
   });
 })

--- a/test/mouse-position-test.js
+++ b/test/mouse-position-test.js
@@ -9,14 +9,14 @@ describe("makeMousePositionDriver", () => {
       const sources = makeMousePositionDriver()();
 
       sources.positions().take(1).addListener({
-        next: () => {
-          const event = simulant('mousemove');
-
-          simulant.fire(document.body, event);
-        },
+        next: () => {},
         error: done,
         complete: done
       });
+
+      const event = simulant('mousemove');
+
+      simulant.fire(document.body, event);
     });
   });
 })

--- a/test/mouse-position-test.js
+++ b/test/mouse-position-test.js
@@ -1,12 +1,13 @@
 import {makeMousePositionDriver} from '../src/mouse-position-driver';
+import xstreamAdapter from '@cycle/xstream-adapter';
+import rxAdapter from '@cycle/rx-adapter';
 
-import assert from 'assert';
 import simulant from 'simulant';
 
-describe("makeMousePositionDriver", () => {
-  describe("positions", () => {
-    it("returns a stream of mouse positions", (done) => {
-      const sources = makeMousePositionDriver()();
+describe('makeMousePositionDriver', () => {
+  describe('positions', () => {
+    it('returns a stream of mouse positions', (done) => {
+      const sources = makeMousePositionDriver()({}, xstreamAdapter);
 
       sources.positions().take(1).addListener({
         next: () => {},
@@ -18,5 +19,15 @@ describe("makeMousePositionDriver", () => {
 
       simulant.fire(document.body, event);
     });
+
+    it('is stream library agnostic', (done) => {
+      const sources = makeMousePositionDriver()({}, rxAdapter);
+
+      sources.positions().take(1).subscribe(() => done());
+
+      const event = simulant('mousemove');
+
+      simulant.fire(document.body, event);
+    });
   });
-})
+});


### PR DESCRIPTION
Removes RxJs in favour of xstream, and updates so that users can use any stream library they want.
